### PR TITLE
Expose Task.await timeout as a Env Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ And tell Alchemy where to send your results:
 # config/config.exs
 use Mix.Config
 
-config :alchemy,
-  publish_module: MyApp.ExperimentPublisher
+config :alchemy, publish_module: MyApp.ExperimentPublisher
+
+# configure alchemy's await timeout
+# default await timeout: 5_000
+config :alchemy, await_timeout: 100_000
 ```
 
 The publish function allows you to publish your results in whatever makes most sense for your application. You could persist them in ETS tables or stash them in Redis.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The experiment is now running but its not being published anywhere. To do that w
 
 ``` elixir
 defmodule MyApp.ExperimentPublisher do
+  require Logger
+  alias Alchemy.Result
+
   def publish(result=%Alchemy.Result{}) do
     name       = result.experiment.name
     control    = result.control
@@ -67,8 +70,8 @@ defmodule MyApp.ExperimentPublisher do
     mismatched = Result.mismatched?(result)
 
     Logger.debug """
-    Test: #{experiment.name}
-    Mismatch?: #{Result.mismatched?(result)}
+    Test: #{name}
+    Match?: #{!Result.mismatched?(result)}
     Control - value: #{control.value} | duration: #{control.duration}
     Candidate - value: #{candidate.value} | duration: #{candidate.duration}
     """

--- a/lib/alchemy/experiment.ex
+++ b/lib/alchemy/experiment.ex
@@ -10,7 +10,7 @@ defmodule Alchemy.Experiment do
   Generates a new experiment struct
   """
   def experiment(title) do
-    %Experiment{name: title, uuid: uuid}
+    %Experiment{name: title, uuid: uuid()}
     |> comparator(fn(a, b) -> a == b end)
   end
 

--- a/lib/alchemy/experiment.ex
+++ b/lib/alchemy/experiment.ex
@@ -98,6 +98,6 @@ defmodule Alchemy.Experiment do
   end
 
   defp await(thunk) do
-    Task.await(thunk)
+    Task.await(thunk, Application.get_env(:alchemy, :await_timeout, 5_000))
   end
 end

--- a/lib/alchemy/publisher.ex
+++ b/lib/alchemy/publisher.ex
@@ -16,7 +16,7 @@ defmodule Alchemy.Publisher do
   end
 
   def handle_call({:publish, result}, _from, state) do
-    user_defined_publisher.publish(result)
+    user_defined_publisher().publish(result)
     {:reply, result, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Alchemy.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "uuid": {:hex, :uuid, "1.1.3"}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []}}


### PR DESCRIPTION
Multiple things on this pull request:

1. Task.await timeout param exposed as a env config.
2. Mix.lock updated, maybe by Elixir 1.4??
3. Fixes on README Publish example.
4. Warning Fixes. adding some parenthesis to ambiguous variables. 

TODO Fix one warning: `user_defined_publisher` parenthesis ambiguous. but In this case `user_defined_publisher` is a Module. so, I didn't add parenthesis. `user_defined_publisher().publish(result)` looks weird

```
  def handle_call({:publish, result}, _from, state) do
    user_defined_publisher.publish(result)
    {:reply, result, state}
  end

  defp user_defined_publisher do
    Application.fetch_env!(:alchemy, :publish_module)
  end
```